### PR TITLE
Add method generate_plugin_template

### DIFF
--- a/hookman/cli.py
+++ b/hookman/cli.py
@@ -30,7 +30,7 @@ def main(specs_path, dst_path):
 
     hook_specs_path = Path(specs_path)
     hm_generator = HookManGenerator(hook_spec_file_path=hook_specs_path)
-    hm_generator.generate_files(Path(dst_path))
+    hm_generator.generate_project_files(Path(dst_path))
 
     return 0
 

--- a/tasks.py
+++ b/tasks.py
@@ -97,7 +97,7 @@ def generate_files(ctx):
         # os.makedirs(dir_for_compilation)
 
         hm_generator = HookManGenerator(hook_spec_file_path=hook_spec_path)
-        hm_generator.generate_files(dst_path=dir_for_compilation)
+        hm_generator.generate_project_files(dst_path=dir_for_compilation)
 
         with open(dir_for_compilation / 'CMakeLists.txt', mode='w+') as file:
             file.write(dedent("""\
@@ -129,7 +129,6 @@ def generate_files(ctx):
                 ))
 
 
-
 @invoke.task
 def build(ctx):
     """
@@ -142,7 +141,7 @@ def build(ctx):
 
 def _create_zip_files(ctx):
     """
-    This functions can be just called when the generate_files and compile tasks have been already invoked
+    This functions can be just called when the generate_project_files and compile tasks have been already invoked
     """
     import shutil
     from pathlib import Path

--- a/tests/test_hookman_generator.py
+++ b/tests/test_hookman_generator.py
@@ -33,7 +33,6 @@ def test_hook_man_generator(datadir):
 
 
 def test_generate_plugin_template(datadir):
-    print(datadir)
     plugin_dir = datadir / 'test_generate_plugin_template'
     hg = HookManGenerator(hook_spec_file_path=Path(datadir / 'hook_specs.py'))
 

--- a/tests/test_hookman_generator.py
+++ b/tests/test_hookman_generator.py
@@ -6,7 +6,6 @@ from hookman.hookman_generator import HookManGenerator
 
 
 def test_hook_man_generator(datadir):
-
     # Pass a folder
     with pytest.raises(FileNotFoundError, match=f"File not found: *"):
         HookManGenerator(hook_spec_file_path=datadir)
@@ -17,7 +16,7 @@ def test_hook_man_generator(datadir):
         HookManGenerator(hook_spec_file_path=Path(datadir / 'invalid_spec.py'))
 
     hg = HookManGenerator(hook_spec_file_path=Path(datadir / 'hook_specs.py'))
-    hg.generate_files(dst_path=datadir)
+    hg.generate_project_files(dst_path=datadir)
 
     obtained_hook_specs_file = datadir / 'plugin' / 'hook_specs.h'
     expected_hook_specs_file = datadir / 'expected_hook_specs.h'
@@ -31,3 +30,42 @@ def test_hook_man_generator(datadir):
     assert obtained_hook_specs_file.read_text() == expected_hook_specs_file.read_text()
     assert obtained_hook_caller_file.read_text() == expected_hook_caller_file.read_text()
     assert obtained_hook_caller_python_file.read_text() == expected_hook_caller_python_file.read_text()
+
+
+def test_generate_plugin_template(datadir):
+    print(datadir)
+    plugin_dir = datadir / 'test_generate_plugin_template'
+    hg = HookManGenerator(hook_spec_file_path=Path(datadir / 'hook_specs.py'))
+
+    hg.generate_plugin_template(
+        plugin_name='Acme',
+        shared_lib_name='acme',
+        author_name='FOO',
+        author_email='FOO@FOO.com',
+        dst_path=plugin_dir
+    )
+
+    obtained_hook_specs_file = datadir / 'test_generate_plugin_template/Acme/hook_specs.h'
+    expected_hook_specs_file = datadir / 'test_generate_plugin_template/expected_hook_specs.h'
+
+    obtained_config_yaml = datadir / 'test_generate_plugin_template/Acme/config.yaml'
+    expected_config_yaml = datadir / 'test_generate_plugin_template/expected_config.yaml'
+
+    obtained_plugin_c = datadir / 'test_generate_plugin_template/Acme/plugin.c'
+    expected_plugin_c = datadir / 'test_generate_plugin_template/expected_plugin.c'
+
+    obtained_readme = datadir / 'test_generate_plugin_template/Acme/readme.md'
+    expected_readme = datadir / 'test_generate_plugin_template/expected_readme.md'
+
+    obtained_cmake_list = datadir / 'test_generate_plugin_template/Acme/CMakeLists.txt'
+    expected_cmake_list = datadir / 'test_generate_plugin_template/expected_cmakelists.txt'
+
+    obtained_build_script = datadir / 'test_generate_plugin_template/Acme/build.py'
+    expected_build_script = datadir / 'test_generate_plugin_template/expected_build.py'
+
+    assert obtained_hook_specs_file.read_text() == expected_hook_specs_file.read_text()
+    assert obtained_config_yaml.read_text() == expected_config_yaml.read_text()
+    assert obtained_plugin_c.read_text() == expected_plugin_c.read_text()
+    assert obtained_readme.read_text() == expected_readme.read_text()
+    assert obtained_cmake_list.read_text() == expected_cmake_list.read_text()
+    assert obtained_build_script.read_text() == expected_build_script.read_text()

--- a/tests/test_hookman_generator/test_generate_plugin_template/expected_build.py
+++ b/tests/test_hookman_generator/test_generate_plugin_template/expected_build.py
@@ -1,0 +1,20 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+current_dir = Path(os.getcwd())
+build_dir = current_dir / "build"
+shared_lib = build_dir / "Release/acme.dll"
+
+if build_dir.exists():
+    shutil.rmtree(build_dir)
+
+build_dir.mkdir()
+
+binary_directory_path = f"-B{str(build_dir)}"
+home_directory_path = f"-H{current_dir}"
+
+subprocess.run(["cmake", binary_directory_path, home_directory_path])
+subprocess.run(["cmake", "--build", str(build_dir), "--config", "Release"])
+subprocess.run(["cp", str(shared_lib), str(current_dir)])

--- a/tests/test_hookman_generator/test_generate_plugin_template/expected_cmakelists.txt
+++ b/tests/test_hookman_generator/test_generate_plugin_template/expected_cmakelists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.5.2)
+
+set(PROJECT_NAME acme)
+project (acme LANGUAGES CXX C)
+
+if(NOT WIN32)
+  set(CMAKE_C_COMPILER    clang)
+  set(CMAKE_CXX_COMPILER  clang++)
+  set(CMAKE_C_FLAGS       "-Wall -std=c99")
+  set(CMAKE_C_FLAGS_DEBUG "-g")
+endif(NOT WIN32)
+
+set(CMAKE_CXX_FLAGS       "-Wall -Werror=return-type -ftemplate-depth=1024")
+set(CMAKE_CXX_LINK_FLAGS  "-lstdc++")
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+
+
+set(CMAKE_C_STANDARD 99)
+
+add_library(acme SHARED plugin.c hook_specs.h)
+install(TARGETS acme EXPORT ${PROJECT_NAME}_export DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/test_hookman_generator/test_generate_plugin_template/expected_config.yaml
+++ b/tests/test_hookman_generator/test_generate_plugin_template/expected_config.yaml
@@ -1,0 +1,5 @@
+plugin_name: 'Acme'
+plugin_version: '1'
+author: 'FOO'
+email: 'FOO@FOO.com'
+shared_lib: 'acme'

--- a/tests/test_hookman_generator/test_generate_plugin_template/expected_hook_specs.h
+++ b/tests/test_hookman_generator/test_generate_plugin_template/expected_hook_specs.h
@@ -1,0 +1,14 @@
+#ifndef ACME_HOOK_SPECS_HEADER_FILE
+#define ACME_HOOK_SPECS_HEADER_FILE
+#ifdef WIN32
+    #define HOOKMAN_API_EXP __declspec(dllexport)
+    #define HOOKMAN_FUNC_EXP __cdecl
+#else
+    #define HOOKMAN_API_EXP
+    #define HOOKMAN_FUNC_EXP
+#endif
+
+#define INIT_HOOKS() HOOKMAN_API_EXP char* HOOKMAN_FUNC_EXP acme_version_api() {return "v1";}
+#define HOOK_FRICTION_FACTOR(v1, v2) HOOKMAN_API_EXP int HOOKMAN_FUNC_EXP acme_v1_friction_factor(int v1, int v2)
+
+#endif

--- a/tests/test_hookman_generator/test_generate_plugin_template/expected_plugin.c
+++ b/tests/test_hookman_generator/test_generate_plugin_template/expected_plugin.c
@@ -1,0 +1,5 @@
+#include "hook_specs.h"
+
+INIT_HOOKS()
+
+// HOOK_FRICTION_FACTOR(v1, v2){}

--- a/tests/test_hookman_generator/test_generate_plugin_template/expected_readme.md
+++ b/tests/test_hookman_generator/test_generate_plugin_template/expected_readme.md
@@ -1,0 +1,46 @@
+ Plugin: 'Acme'
+ Author: 'FOO'
+ Email: 'FOO@FOO.com'
+
+ This is a sample readme file with the supported syntax, the content of this file should be write in markdown.
+
+ Here's an overview of the syntax that you can use to write the content of this file:
+
+ Headers
+    # This is equivalent an <h1> tag on html
+    ## This equivalent an <h2> tag on html
+
+ Emphasis
+    *This text will be italic*
+    _This will also be italic_
+
+    **This text will be bold**
+    __This will also be bold__
+
+Lists
+    Unordered
+        * Item 1
+        * Item 2
+            * Item 2a
+            * Item 2b
+    Ordered
+        1. Item 1
+        2. Item 2
+        3. Item 3
+           3.1. Item 3a
+           3.2. Item 3b
+
+Images
+    Format: ![Alt Text](url)
+
+Links
+    http://github.com - automatic!
+    [Display Name](http://<link>)
+
+Blockquotes
+    > Blockquote
+    >> Nested blockquote
+
+Inline code
+    ` some code `
+


### PR DESCRIPTION
This commit adds a new public method name `generate_plugin_template`

With this command, it's possible to create a "boilerplate" for a plugin.

In order to create a boilerplate it's necessary to pass the following argument:

|Argument | Description |
| --- | --- |
|`plugin_name` | Name of the plugin to be displayed |
|`shared_lib_name` | The filename of the compiled plugin|
|`author_email` | Name of the plugin author to be displayed|
|`author_name` | Email of the plugin author to be displayed|
|`dst_path` | Path to where the template generated should be placed|

The generated template has the following files:

|File | Description |
| --- | --- |
|`config.yml` | File with necessary information about the plugin to the application using this plugin |
|`plugin.c` | Source file of the plugin |
|`hook_specs.h` | Header file with all the information necessary to create a plugin for the given application |
|`CMakeLists` | CMake file with the minimum configuration necessary to build a shared library across different platforms |
|`README` | Readme file with the description of the Plugin, to be used by the application. |

