### PR TITLE
Add a validation for shared_lib_name

### DIFF
--- a/hookman/hookman_generator.py
+++ b/hookman/hookman_generator.py
@@ -136,10 +136,7 @@ class HookManGenerator:
             - README.md
         """
         if not shared_lib_name.isidentifier():
-            raise HookmanError("""
-            The shared libray name should be a valid identifier, with letters A through Z, underscore _
-            and, except for the first character, the digits 0 through 9
-            """)
+            raise HookmanError("The shared libray name must be a valid identifier.")
 
         plugin_folder = dst_path / shared_lib_name
         assets_folder = plugin_folder / 'assets'

--- a/hookman/hookman_generator.py
+++ b/hookman/hookman_generator.py
@@ -9,7 +9,7 @@ from typing import NamedTuple
 from zipfile import ZipFile
 
 from hookman.exceptions import (
-    ArtifactsDirNotFoundError, AssetsDirNotFoundError, SharedLibraryNotFoundError)
+    ArtifactsDirNotFoundError, AssetsDirNotFoundError, HookmanError, SharedLibraryNotFoundError)
 from hookman.hooks import HookSpecs
 from hookman.plugin_config import PluginInfo
 
@@ -127,13 +127,21 @@ class HookManGenerator:
             dst_path: Path):
         """
         Generate a template with the necessary files and structure to create a plugin
+
+        A folder with the same name as the shared_lib_name argument will be created, with the following files:
             - config.yml
             - plugin.c
             - hook_specs.h
             - CMakeLists.txt
             - README.md
         """
-        plugin_folder = dst_path / plugin_name
+        if not shared_lib_name.isidentifier():
+            raise HookmanError("""
+            The shared libray name should be a valid identifier, with letters A through Z, underscore _
+            and, except for the first character, the digits 0 through 9
+            """)
+
+        plugin_folder = dst_path / shared_lib_name
         assets_folder = plugin_folder / 'assets'
         source_folder = plugin_folder / 'src'
 
@@ -458,7 +466,7 @@ class HookManGenerator:
             set(CMAKE_CXX_FLAGS_DEBUG "-g")
 
             set(CMAKE_C_STANDARD 99)
-            
+
             project ({shared_lib_name} LANGUAGES CXX C)
             add_subdirectory(src)
         ''')

--- a/tests/test_hookman_generator.py
+++ b/tests/test_hookman_generator.py
@@ -74,7 +74,39 @@ def test_generate_plugin_template(datadir):
     assert obtained_cmake_list_src.read_text() == expected_cmake_list_src.read_text()
 
 
-def test_generate_plugin_package(simple_plugin, acme_hook_specs_file, tmpdir):
+def test_generate_plugin_package_invalid_shared_lib_name(acme_hook_specs_file, tmpdir):
+    hg = HookManGenerator(hook_spec_file_path=acme_hook_specs_file)
+
+    from hookman.exceptions import HookmanError
+    with pytest.raises(HookmanError):
+        hg.generate_plugin_template(
+            plugin_name='acme',
+            shared_lib_name='acm#e',
+            author_email='acme1',
+            author_name='acme2',
+            dst_path=Path(tmpdir)
+        )
+
+    with pytest.raises(HookmanError):
+        hg.generate_plugin_template(
+            plugin_name='acme',
+            shared_lib_name='acm e',
+            author_email='acme1',
+            author_name='acme2',
+            dst_path=Path(tmpdir)
+        )
+
+    with pytest.raises(HookmanError):
+        hg.generate_plugin_template(
+            plugin_name='1acme',
+            shared_lib_name='acm e',
+            author_email='acme1',
+            author_name='acme2',
+            dst_path=Path(tmpdir)
+        )
+
+
+def test_generate_plugin_package(acme_hook_specs_file, tmpdir):
     hg = HookManGenerator(hook_spec_file_path=acme_hook_specs_file)
 
     hg.generate_plugin_template(
@@ -117,7 +149,7 @@ def test_generate_plugin_package(simple_plugin, acme_hook_specs_file, tmpdir):
     assert f'artifacts/{shared_lib_name}' in list_of_files
 
 
-def test_generate_plugin_package_with_missing_folders(simple_plugin, acme_hook_specs_file, tmpdir):
+def test_generate_plugin_package_with_missing_folders(acme_hook_specs_file, tmpdir):
     import sys
     from textwrap import dedent
     from hookman.exceptions import AssetsDirNotFoundError, ArtifactsDirNotFoundError, SharedLibraryNotFoundError

--- a/tests/test_hookman_generator.py
+++ b/tests/test_hookman_generator.py
@@ -44,25 +44,26 @@ def test_generate_plugin_template(datadir):
         dst_path=plugin_dir
     )
 
-    obtained_hook_specs_file = datadir / 'test_generate_plugin_template/Acme/src/hook_specs.h'
+    obtained_hook_specs_file = datadir / 'test_generate_plugin_template/acme/src/hook_specs.h'
+    expected_hook_specs_file = datadir / 'test_generate_plugin_template/expected_hook_specs.h'
     expected_hook_specs_file = datadir / 'test_generate_plugin_template/expected_hook_specs.h'
 
-    obtained_plugin_yaml = datadir / 'test_generate_plugin_template/Acme/assets/plugin.yaml'
+    obtained_plugin_yaml = datadir / 'test_generate_plugin_template/acme/assets/plugin.yaml'
     expected_plugin_yaml = datadir / 'test_generate_plugin_template/expected_plugin.yaml'
 
-    obtained_plugin_c = datadir / 'test_generate_plugin_template/Acme/src/plugin.c'
+    obtained_plugin_c = datadir / 'test_generate_plugin_template/acme/src/plugin.c'
     expected_plugin_c = datadir / 'test_generate_plugin_template/expected_plugin.c'
 
-    obtained_readme = datadir / 'test_generate_plugin_template/Acme/assets/README.md'
+    obtained_readme = datadir / 'test_generate_plugin_template/acme/assets/README.md'
     expected_readme = datadir / 'test_generate_plugin_template/expected_readme.md'
 
-    obtained_cmake_list = datadir / 'test_generate_plugin_template/Acme/CMakeLists.txt'
+    obtained_cmake_list = datadir / 'test_generate_plugin_template/acme/CMakeLists.txt'
     expected_cmake_list = datadir / 'test_generate_plugin_template/expected_cmakelists.txt'
 
-    obtained_cmake_list_src = datadir / 'test_generate_plugin_template/Acme/src/CMakeLists.txt'
+    obtained_cmake_list_src = datadir / 'test_generate_plugin_template/acme/src/CMakeLists.txt'
     expected_cmake_list_src = datadir / 'test_generate_plugin_template/expected_cmakelists_src.txt'
 
-    obtained_compile_script = datadir / 'test_generate_plugin_template/Acme/compile.py'
+    obtained_compile_script = datadir / 'test_generate_plugin_template/acme/compile.py'
     expected_compile_script = datadir / 'test_generate_plugin_template/expected_compile.py'
 
     assert obtained_hook_specs_file.read_text() == expected_hook_specs_file.read_text()


### PR DESCRIPTION
Add a validation for shared_lib_name, forcing the shared_lib_name to be a valid identifier.

Also, this pull request modifies the command `generate_plugin_template` to create a folder with the same name as the shared_library argument instead of the plugin name.