### PR TITLE
Add the docstring from the hook definition on the hook_specs header file

### DIFF
--- a/tests/test_hookman_generator/expected_hook_specs.h
+++ b/tests/test_hookman_generator/expected_hook_specs.h
@@ -9,6 +9,14 @@
 #endif
 
 #define INIT_HOOKS() HOOKMAN_API_EXP char* HOOKMAN_FUNC_EXP acme_version_api() {return "v1";}
+
+/*!
+Docs for Friction Factor
+    Input:
+        Testing indentation
+    Return:
+            Integer
+*/
 #define HOOK_FRICTION_FACTOR(v1, v2) HOOKMAN_API_EXP int HOOKMAN_FUNC_EXP acme_v1_friction_factor(int v1, double v2[2])
 
 #endif

--- a/tests/test_hookman_generator/hook_specs.py
+++ b/tests/test_hookman_generator/hook_specs.py
@@ -4,6 +4,10 @@ from hookman.hooks import HookSpecs
 def friction_factor(v1: 'int', v2: 'double[2]') -> 'int':
     """
     Docs for Friction Factor
+        Input:
+            Testing indentation
+        Return:
+                Integer
     """
 
 

--- a/tests/test_hookman_generator/test_generate_plugin_template/expected_hook_specs.h
+++ b/tests/test_hookman_generator/test_generate_plugin_template/expected_hook_specs.h
@@ -9,6 +9,14 @@
 #endif
 
 #define INIT_HOOKS() HOOKMAN_API_EXP char* HOOKMAN_FUNC_EXP acme_version_api() {return "v1";}
+
+/*!
+Docs for Friction Factor
+    Input:
+        Testing indentation
+    Return:
+            Integer
+*/
 #define HOOK_FRICTION_FACTOR(v1, v2) HOOKMAN_API_EXP int HOOKMAN_FUNC_EXP acme_v1_friction_factor(int v1, double v2[2])
 
 #endif


### PR DESCRIPTION
As described on issue https://github.com/ESSS/hookman/issues/2, this pull request uses the docstring from the hook declaration (`hook_specs.py`) and insert above each declaration on hook_specs.h

Close #2