### PR TITLE
Fix compilation of py::bind_vector for VS 15.9.x

### DIFF
--- a/hookman/hookman_generator.py
+++ b/hookman/hookman_generator.py
@@ -404,7 +404,7 @@ class HookManGenerator:
         for index, (r_type, args_type) in enumerate(sorted(signatures)):
             name = f'vector_hook_impl_type_{index}'
             vector_type = f"std::vector<std::function<{r_type}({args_type})>>"
-            content_lines.append(f'    py::bind_vector<{vector_type}>(m, "{name}");')
+            content_lines.append(f'    py::bind_vector<{vector_type}>(m, "{name}", "Hook for vector implementation type {index}");')
         content_lines.append("")
 
         content_lines += [

--- a/tests/test_hookman_generator/HookCallerPython.cpp
+++ b/tests/test_hookman_generator/HookCallerPython.cpp
@@ -8,7 +8,7 @@ namespace py = pybind11;
 PYBIND11_MAKE_OPAQUE(std::vector<std::function<int(int, double[2])>>);
 
 PYBIND11_MODULE(_test_hook_man_generator, m) {
-    py::bind_vector<std::vector<std::function<int(int, double[2])>>>(m, "vector_hook_impl_type_0");
+    py::bind_vector<std::vector<std::function<int(int, double[2])>>>(m, "vector_hook_impl_type_0", "Hook for vector implementation type 0");
 
     py::class_<hookman::HookCaller>(m, "HookCaller")
         .def(py::init<>())


### PR DESCRIPTION
The newer VS compiler version are giving compile errors for py::bind_vector. The fix is based on https://github.com/pybind/pybind11/issues/1616#issuecomment-445184631