### PR TITLE
Explicitly declare 'extern "C"' in hook_specs.h

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -33,6 +33,8 @@ History
   * ``python -m hookman generate-hook-specs-h``
   * ``python -m hookman package-plugin``
 
+- Explicitly declare ``extern "C"`` calling convention in the ``hook_specs.h`` file.
+
 0.1.7 (2018-08-23)
 ------------------
 

--- a/hookman/hookman_generator.py
+++ b/hookman/hookman_generator.py
@@ -317,13 +317,22 @@ class HookManGenerator:
             #define HOOKMAN_FUNC_EXP
         #endif
 
+        #ifdef __cplusplus
+        extern "C" {{
+        #endif
+
         #define INIT_HOOKS() HOOKMAN_API_EXP const char* HOOKMAN_FUNC_EXP {self.project_name}_version_api() {{return \"{self.version}\";}}
         HOOKMAN_API_EXP const char* HOOKMAN_FUNC_EXP get_plugin_name() {{return \"{shared_lib_name}\";}}
 
         """)
         file_content += list_with_hook_specs_with_documentation
         file_content += dedent(f"""
+
+        #ifdef __cplusplus
+        }} // extern "C"
         #endif
+
+        #endif // {self.project_name.upper()}_HOOK_SPECS_HEADER_FILE
         """)
         return file_content
 

--- a/tests/test_hookman_generator/generate_hook_specs.h
+++ b/tests/test_hookman_generator/generate_hook_specs.h
@@ -9,6 +9,10 @@
     #define HOOKMAN_FUNC_EXP
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define INIT_HOOKS() HOOKMAN_API_EXP const char* HOOKMAN_FUNC_EXP acme_version_api() {return "v1";}
 HOOKMAN_API_EXP const char* HOOKMAN_FUNC_EXP get_plugin_name() {return "acme";}
 
@@ -33,4 +37,9 @@ Same signature as 'friction_factor' for testing.
 */
 #define HOOK_FRICTION_FACTOR_2(v1, v2) HOOKMAN_API_EXP int HOOKMAN_FUNC_EXP acme_v1_friction_factor_2(int v1, double v2[2])
 
+
+#ifdef __cplusplus
+} // extern "C"
 #endif
+
+#endif // ACME_HOOK_SPECS_HEADER_FILE

--- a/tests/test_hookman_generator/generate_hook_specs_header1.h
+++ b/tests/test_hookman_generator/generate_hook_specs_header1.h
@@ -9,6 +9,10 @@
     #define HOOKMAN_FUNC_EXP
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define INIT_HOOKS() HOOKMAN_API_EXP const char* HOOKMAN_FUNC_EXP acme_version_api() {return "v1";}
 HOOKMAN_API_EXP const char* HOOKMAN_FUNC_EXP get_plugin_name() {return "acme";}
 
@@ -33,4 +37,9 @@ Same signature as 'friction_factor' for testing.
 */
 #define HOOK_FRICTION_FACTOR_2(v1, v2) HOOKMAN_API_EXP int HOOKMAN_FUNC_EXP acme_v1_friction_factor_2(int v1, double v2[2])
 
+
+#ifdef __cplusplus
+} // extern "C"
 #endif
+
+#endif // ACME_HOOK_SPECS_HEADER_FILE

--- a/tests/test_hookman_generator/generate_hook_specs_header2.h
+++ b/tests/test_hookman_generator/generate_hook_specs_header2.h
@@ -9,6 +9,10 @@
     #define HOOKMAN_FUNC_EXP
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define INIT_HOOKS() HOOKMAN_API_EXP const char* HOOKMAN_FUNC_EXP acme_version_api() {return "v1";}
 HOOKMAN_API_EXP const char* HOOKMAN_FUNC_EXP get_plugin_name() {return "acme";}
 
@@ -22,4 +26,9 @@ Docs for Friction Factor
 */
 #define HOOK_FRICTION_FACTOR(v1, v2) HOOKMAN_API_EXP int HOOKMAN_FUNC_EXP acme_v1_friction_factor(int v1, double v2[2])
 
+
+#ifdef __cplusplus
+} // extern "C"
 #endif
+
+#endif // ACME_HOOK_SPECS_HEADER_FILE


### PR DESCRIPTION
This allows us to compile the hooks in a C++ compiler