### PR TITLE
Change cmake config to use gcc

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -6,8 +6,8 @@ set(PROJECT_NAME hookman)
 set(ARTIFACTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/artifacts)
 
 if(NOT WIN32)
-  set(CMAKE_C_COMPILER    clang)
-  set(CMAKE_CXX_COMPILER  clang++)
+  set(CMAKE_C_COMPILER    gcc)
+  set(CMAKE_CXX_COMPILER  gcc)
 endif(NOT WIN32)
 
 project (hookman LANGUAGES CXX C)

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -6,8 +6,8 @@ set(PROJECT_NAME hookman)
 set(ARTIFACTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/artifacts)
 
 if(NOT WIN32)
-  set(CMAKE_C_COMPILER    gcc)
-  set(CMAKE_CXX_COMPILER  gcc)
+  set(CMAKE_C_COMPILER    cc)
+  set(CMAKE_CXX_COMPILER  c++)
 endif(NOT WIN32)
 
 project (hookman LANGUAGES CXX C)

--- a/build/HookManConfig.cmake
+++ b/build/HookManConfig.cmake
@@ -29,7 +29,7 @@ if(NOT WIN32)
   message(STATUS "Found GCC base directory: ${GCC_BASE_DIR}")
 
   set(CMAKE_CXX_FLAGS       "-Wall")
-  set(CMAKE_CXX_LINK_FLAGS  "-lstdc++")
+  set(CMAKE_CXX_LINK_FLAGS  "-std=c++11")
   set(CMAKE_CXX_FLAGS_DEBUG "-g")
 
 endif(NOT WIN32)

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -17,7 +17,9 @@ dependencies:
     - cmake >=3.5.2
 
     {% if os.sys.platform != 'win32' %}
-    - clangdev>=6.0.0
+    - cxx-compiler
+    - c-compiler
+    - cython
     {% endif %}
 
     {% if os.sys.platform == 'win32' %}

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -17,8 +17,7 @@ dependencies:
     - cmake >=3.5.2
 
     {% if os.sys.platform != 'win32' %}
-    - cxx-compiler
-    - c-compiler
+    - compilers
     - cython
     {% endif %}
 

--- a/hookman/hookman_generator.py
+++ b/hookman/hookman_generator.py
@@ -589,13 +589,13 @@ class HookManGenerator:
             set(ARTIFACTS_DIR ${{CMAKE_CURRENT_SOURCE_DIR}}/artifacts)
 
             if(NOT WIN32)
-              set(CMAKE_C_COMPILER    clang)
-              set(CMAKE_CXX_COMPILER  clang++)
+              set(CMAKE_C_COMPILER    cc)
+              set(CMAKE_CXX_COMPILER  c++)
               set(CMAKE_C_FLAGS       "-Wall -std=c99")
               set(CMAKE_C_FLAGS_DEBUG "-g")
             endif(NOT WIN32)
 
-            set(CMAKE_CXX_LINK_FLAGS  "-lstdc++")
+            set(CMAKE_CXX_LINK_FLAGS  "-std=c++11")
             set(CMAKE_CXX_FLAGS_DEBUG "-g")
 
             set(CMAKE_C_STANDARD 99)


### PR DESCRIPTION
This PR changes the C and C++ compilers to use gcc family instead clang as required in #70.

Remarks:

* I changed the code generation in `hookman/hookman_generator.py`, please see lines 592-598 there.

* Instead installing `clang-dev` from `conda-forge`, now `compilers` is required (as we need both C and C++ compilers).

* One of the tests is failing. The error is related to `pytest-datadir` and file regression. I have no previous experiences with this plugin and I have been facing some struggle with it. I need some help in this regard.

Thanks in advance.