### PR TITLE
Add reorder-python-imports pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: debug-statements
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.6.0
+    hooks:
+    -   id: reorder-python-imports
+        args: ['--application-directories=.:src', --py36-plus]
 -   repo: local
     hooks:
     -   id: rst

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,9 +5,7 @@
 # This file does only contain a selection of the most common options. For a
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/stable/config
-
 # -- Path setup --------------------------------------------------------------
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -15,8 +13,6 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-
-
 # -- Project information -----------------------------------------------------
 
 project = "HookMan"

--- a/hookman/__init__.py
+++ b/hookman/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """Top-level package for Hookman."""
 
 __author__ = """ESSS"""

--- a/hookman/__main__.py
+++ b/hookman/__main__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-
 """Console script for hookman."""
 import sys
 from pathlib import Path
 
 import click
+
 from hookman.hookman_generator import HookManGenerator
 
 

--- a/hookman/hookman_generator.py
+++ b/hookman/hookman_generator.py
@@ -4,12 +4,20 @@ import re
 import sys
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Dict, List, NamedTuple, Optional, Union
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import NamedTuple
+from typing import Optional
+from typing import Union
 from zipfile import ZipFile
 
-from hookman.exceptions import ArtifactsDirNotFoundError, AssetsDirNotFoundError, HookmanError
+from hookman.exceptions import ArtifactsDirNotFoundError
+from hookman.exceptions import AssetsDirNotFoundError
+from hookman.exceptions import HookmanError
 from hookman.hooks import HookSpecs
-from hookman.plugin_config import PLUGIN_CONFIG_SCHEMA, PluginInfo
+from hookman.plugin_config import PLUGIN_CONFIG_SCHEMA
+from hookman.plugin_config import PluginInfo
 
 
 class Hook(NamedTuple):

--- a/hookman/hookman_utils.py
+++ b/hookman/hookman_utils.py
@@ -3,7 +3,9 @@ import os
 import sys
 from contextlib import contextmanager
 from pathlib import Path
-from typing import List, Sequence, Union
+from typing import List
+from typing import Sequence
+from typing import Union
 
 
 def find_config_files(

--- a/hookman/hooks.py
+++ b/hookman/hooks.py
@@ -1,11 +1,15 @@
 import inspect
 import shutil
 from pathlib import Path
-from typing import Callable, List, Optional, Sequence
+from typing import Callable
+from typing import List
+from typing import Optional
+from typing import Sequence
 from zipfile import ZipFile
 
 from hookman import hookman_utils
-from hookman.exceptions import InvalidDestinationPathError, PluginAlreadyInstalledError
+from hookman.exceptions import InvalidDestinationPathError
+from hookman.exceptions import PluginAlreadyInstalledError
 from hookman.plugin_config import PluginInfo
 
 

--- a/hookman/plugin_config.py
+++ b/hookman/plugin_config.py
@@ -6,11 +6,13 @@ from zipfile import ZipFile
 
 import attr
 from attr import attrib
+from strictyaml import Map
+from strictyaml import MapPattern
+from strictyaml import Optional
+from strictyaml import Str
 
 from hookman.exceptions import SharedLibraryNotFoundError
 from hookman.hookman_utils import load_shared_lib
-
-from strictyaml import Map, MapPattern, Optional, Str
 
 PLUGIN_CONFIG_SCHEMA = Map(
     {

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 """The setup script."""
-
-from setuptools import find_packages, setup
+from setuptools import find_packages
+from setuptools import setup
 
 with open("README.rst") as readme_file:
     readme = readme_file.read()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,6 +1,8 @@
 import pytest
 
-from hookman.hooks import HookMan, HookSpecs, PluginInfo
+from hookman.hooks import HookMan
+from hookman.hooks import HookSpecs
+from hookman.hooks import PluginInfo
 
 
 def _get_plugin_id_set(plugin_info_list):


### PR DESCRIPTION
This keeps imports organized automatically in a way to avoid conflicts. See [the docs](https://github.com/asottile/reorder_python_imports#why-this-style) for the rationale.