### PR TITLE
Add CHANGELOG.rst to plugin generator

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ UNRELEASED
 ==========
 
 - Dropped support for old Python versions, requiring Python 3.10+.
+- Add CHANGELOG.rst to plugin generator
 
 0.5.0 (2023-02-10)
 ==================

--- a/hookman/hookman_generator.py
+++ b/hookman/hookman_generator.py
@@ -161,6 +161,7 @@ class HookManGenerator:
                 assets/
                     - plugin.yaml
                     - README.md
+                    - CHANGELOG.rst
                 src/
                     - hook_specs.h
                     - {plugin_id}.cpp
@@ -207,6 +208,7 @@ class HookManGenerator:
         Path(assets_folder / "README.md").write_text(
             self._readme_content(caption, author_email, author_name)
         )
+        Path(assets_folder / "CHANGELOG.rst").write_text(self._changelog_content(caption))
         Path(source_folder / "hook_specs.h").write_text(self._hook_specs_header_content(plugin_id))
         Path(source_folder / f"{plugin_id}.cpp").write_text(
             self._plugin_source_content(extra_includes, extra_body_lines, exclude_hooks)
@@ -279,6 +281,7 @@ class HookManGenerator:
             - plugin.yml
             - shared library (.ddl or .so)
             - readme.md
+            - changelog.rst
 
         Per default, the package will be created inside the folder plugin_dir, however it's possible
         to give another path filling the dst argument
@@ -345,6 +348,7 @@ class HookManGenerator:
 
             - The assets folder needs to contain:
                 - Readme.md
+                - changelog.rst
                 - plugin.yaml
 
             - The artifacts folder need to contain:
@@ -369,6 +373,9 @@ class HookManGenerator:
 
         if not assets_dir.joinpath("README.md").is_file():
             raise FileNotFoundError(f"Unable to locate the file README.md in {assets_dir}")
+
+        if not assets_dir.joinpath("CHANGELOG.rst").is_file():
+            raise FileNotFoundError(f"Unable to locate the file CHANGELOG.rst in {assets_dir}")
 
     def _validate_plugin_config_file(self, plugin_config_file: Path):
         """
@@ -656,6 +663,29 @@ class HookManGenerator:
 
         You can find an overview of the valid tags that can be used to write the content of this file on the following link:
         https://guides.github.com/features/mastering-markdown/#syntax
+        """
+        )
+
+    def _generate_rst_title(self, caption: str) -> str:
+        complement = " Changelog"
+        title = caption + complement
+        border = "=" * (len(title))
+        return f"""{border}
+        {title}
+        {border}
+        """
+
+    def _changelog_content(self, caption: str) -> str:
+        return dedent(
+            f"""\
+        {self._generate_rst_title(caption)}
+        1.0.0 (Unreleased)
+        ==================
+
+        Major highlights
+        ------------------
+
+        * Example feature A
         """
         )
 

--- a/tests/plugins/acme/simple_plugin/assets/CHANGELOG.rst
+++ b/tests/plugins/acme/simple_plugin/assets/CHANGELOG.rst
@@ -1,0 +1,10 @@
+=======================
+Simple Plugin Changelog
+=======================
+
+1.0.0 (Unreleased)
+==================
+
+Major highlights
+------------------
+* Example feature A

--- a/tests/plugins/acme/simple_plugin_2/assets/CHANGELOG.rst
+++ b/tests/plugins/acme/simple_plugin_2/assets/CHANGELOG.rst
@@ -1,0 +1,10 @@
+=========================
+Simple Plugin 2 Changelog
+=========================
+
+1.0.0 (Unreleased)
+==================
+
+Major highlights
+------------------
+* Example feature A

--- a/tests/test_hookman_generator.py
+++ b/tests/test_hookman_generator.py
@@ -69,6 +69,11 @@ def test_generate_plugin_template(datadir, file_regression):
     obtained_readme = datadir / "test_generate_plugin_template/acme/assets/README.md"
     file_regression.check(obtained_readme.read_text(), basename="generate_README", extension=".md")
 
+    obtained_changelog = datadir / "test_generate_plugin_template/acme/assets/CHANGELOG.rst"
+    file_regression.check(
+        obtained_changelog.read_text(), basename="generate_CHANGELOG", extension=".rst"
+    )
+
     obtained_cmake_list = datadir / "test_generate_plugin_template/acme/CMakeLists.txt"
     file_regression.check(
         obtained_cmake_list.read_text(), basename="generate_CMakeLists", extension=".txt"
@@ -335,6 +340,13 @@ def test_generate_plugin_package_with_missing_folders(acme_hook_specs_file, tmpd
 
     readme_file = asset_dir / "README.md"
     readme_file.write_text("")
+
+    # -- Without changelog file
+    with pytest.raises(FileNotFoundError, match=f"Unable to locate the file CHANGELOG.rst in"):
+        hg.generate_plugin_package(package_name="acme", plugin_dir=plugin_dir)
+
+    changelog_file = asset_dir / "CHANGELOG.rst"
+    changelog_file.write_text("")
 
     # # -- With a invalid shared_library name on config_file
     acme_lib_name = "acme.dll" if sys.platform == "win32" else "libacme.so"

--- a/tests/test_hookman_generator/generate_CHANGELOG.rst
+++ b/tests/test_hookman_generator/generate_CHANGELOG.rst
@@ -1,0 +1,11 @@
+==============
+Acme Changelog
+==============
+
+1.0.0 (Unreleased)
+==================
+
+Major highlights
+------------------
+
+* Example feature A


### PR DESCRIPTION
A common concern when developing a software with versioning is what changed from one version to another. Including a CHANGELOG.rst file is proposed here for remembering this type of documentation when creating a plugin.

ASIM-5901
