### PR TITLE
Consider versioned `.so` files during packaging

### DIFF
--- a/hookman/hookman_generator.py
+++ b/hookman/hookman_generator.py
@@ -325,7 +325,9 @@ class HookManGenerator:
         else:
             shared_lib_extension = "*.so"
             shared_lib_versioned_extension = "*.so.[0-9]*"
-            shared_lib_files = list(artifacts_dir.rglob(shared_lib_extension)) + list(artifacts_dir.rglob(shared_lib_versioned_extension))
+            shared_lib_files = list(artifacts_dir.rglob(shared_lib_extension)) + list(
+                artifacts_dir.rglob(shared_lib_versioned_extension)
+            )
             hmplugin_base_name_components.append("linux64")
 
         hmplugin_path = dst_path / ("-".join(hmplugin_base_name_components) + ".hmplugin")
@@ -335,7 +337,7 @@ class HookManGenerator:
                     zip_file.writestr(str(file.relative_to(plugin_dir)), data=contents)
                 else:
                     zip_file.write(filename=file, arcname=file.relative_to(plugin_dir))
-            
+
             for file in shared_lib_files:
                 zip_file.write(filename=file, arcname=file.relative_to(plugin_dir))
 

--- a/tests/test_hookman_generator.py
+++ b/tests/test_hookman_generator.py
@@ -220,7 +220,9 @@ def test_generate_plugin_package(
     import sys
 
     shared_lib_name = f"{plugin_id}.dll" if sys.platform == "win32" else f"lib{plugin_id}.so"
-    shared_dependency_name = f"{plugin_id}_dep.dll" if sys.platform == "win32" else f"lib{plugin_id}_dep.so.2"
+    shared_dependency_name = (
+        f"{plugin_id}_dep.dll" if sys.platform == "win32" else f"lib{plugin_id}_dep.so.2"
+    )
     shared_libs = [shared_lib_name, shared_dependency_name]
 
     for lib_name in shared_libs:


### PR DESCRIPTION
For Linux, I noticed that several dependencies to be copied involve versions, something like `<libName>.so.2`, `<libName>.so.3.0` and so on. The goal is to also copy dependencies with versions