### PR TITLE
Add packaging dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,13 @@ with open("README.rst") as readme_file:
 with open("CHANGELOG.rst") as history_file:
     history = history_file.read()
 
-requirements = ["Click>=7.0", "strictyaml", "invoke", "attrs"]
+requirements = [
+    "attrs",
+    "click>=7.0",
+    "invoke",
+    "packaging",
+    "strictyaml",
+]
 
 setup(
     author="ESSS",


### PR DESCRIPTION
The [build on conda-forge](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1313995&view=logs&jobId=7b6f2c87-f3a7-5133-8d84-7c03a75d9dfc&j=7b6f2c87-f3a7-5133-8d84-7c03a75d9dfc&t=9eb77fd2-8ddd-5444-8fc0-71cb28dcb736) failed with:

```
Traceback (most recent call last):
  File "/home/conda/feedstock_root/build_artifacts/python-hookman_1755547280154/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/bin/hookman", line 7, in <module>
    from hookman.__main__ import cli
  File "/home/conda/feedstock_root/build_artifacts/python-hookman_1755547280154/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib/python3.10/site-packages/hookman/__main__.py", line 8, in <module>
    from hookman.hookman_generator import HookManGenerator
  File "/home/conda/feedstock_root/build_artifacts/python-hookman_1755547280154/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib/python3.10/site-packages/hookman/hookman_generator.py", line 19, in <module>
    from hookman.hooks import HookSpecs
  File "/home/conda/feedstock_root/build_artifacts/python-hookman_1755547280154/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib/python3.10/site-packages/hookman/hooks.py", line 11, in <module>
    from packaging.version import Version
ModuleNotFoundError: No module named 'packaging'
```

`hookman/hooks.py` now depends on `packaging`, so we should define that explicitly.
